### PR TITLE
Add speed sorting before turn, dodge and block logics

### DIFF
--- a/Project/Engine/engine.py
+++ b/Project/Engine/engine.py
@@ -63,6 +63,8 @@ class Engine:
     def single_run(self):
         # execution of each character's action
         leavers = []
+        # sort the players by speed
+        self._arena._playersList.sort(key=lambda x: x.getSpeed(), reverse=True)
         for i in range(self._arena.getTotalNbPlayer()):
             # process damage
             character = self._arena.getPlayerByIndex(i)
@@ -79,22 +81,25 @@ class Engine:
                     cStrength = character.getStrength()
                     tAction, _ = target.getAction()
                     if tAction == ACTION.BLOCK:
-                        target.setLife(tLife - abs(tArmor - cStrength))
-                        statistics["damage"] = abs(tArmor - cStrength)
-                        statistics["reduced"] = tArmor
+                        # We use a logarithmic function to compute the reduced damages
+                        reducedDamages = (1-(tArmor/(tArmor+8))) * cStrength
+                        target.setLife(tLife - reducedDamages)
+                        statistics["damage"] = reducedDamages
+                        statistics["reduced"] = cStrength - reducedDamages
                         statistics["dodged"] = 0
 
                     elif tAction == ACTION.DODGE:
-                        r = randint(1, 10)
+                        # There is a speed/25 chance to dodge an attack (means that there is 80% dodge chance at 20 speed)
                         tSpeed = target.getSpeed()
+                        r = randint(0, 25)
                         statistics["damage"] = 0
                         statistics["reduced"] = 0
                         statistics["dodged"] = 0
-                        if tSpeed > r:
-                            target.setLife(tLife - cStrength)
-                            statistics["damage"] = abs(tArmor - cStrength)
+                        if r <= tSpeed:
+                            statistics["dodged"] = cStrength
                         else:
-                           statistics["dodged"] = min(cStrength, character.getLife())
+                            target.setLife(tLife - cStrength)
+                            statistics["damage"] = cStrength
 
                     else:
                         target.setLife(tLife - cStrength)


### PR DESCRIPTION
Juste avant le début d'un tout, on utilise une fonction lambda pour trier les _characters_ selon leur vitesse.
Ainsi, le personnage avec le plus de vitesse frappera en premier, le second en deuxième, etc.

Nous avons aussi rajouté une logique autour de l'armure qui est logarithmique : plus l'on a d'armure, plus l'augmentation de réduction de dégâts est faible.

Pour ce qui est de l'esquive, celle-ci peut se produire avec vitesse_du_joueur/25 chance, ce qui offre une probabilité de 0.8 à 20 de vitesse. 