### PR TITLE
Fix BLOCK domage & dodge rate balancing

### DIFF
--- a/Project/Engine/engine.py
+++ b/Project/Engine/engine.py
@@ -89,7 +89,7 @@ class Engine:
                         statistics["dodged"] = 0
 
                     elif tAction == ACTION.DODGE:
-                        r = randint(1, 10)
+                        r = randint(1, 20)
                         tSpeed = target.getSpeed()
                         statistics["damage"] = 0
                         statistics["reduced"] = 0

--- a/Project/Engine/engine.py
+++ b/Project/Engine/engine.py
@@ -79,8 +79,12 @@ class Engine:
                     cStrength = character.getStrength()
                     tAction, _ = target.getAction()
                     if tAction == ACTION.BLOCK:
-                        target.setLife(tLife - abs(tArmor - cStrength))
-                        statistics["damage"] = abs(tArmor - cStrength)
+                        if tArmor < cStrength:
+                            target.setLife(tLife - abs(tArmor - cStrength))
+                            statistics["damage"] = abs(tArmor - cStrength)
+                        else:
+                            target.setArmor(tArmor - 1)
+                            statistics["damage"] = 0
                         statistics["reduced"] = tArmor
                         statistics["dodged"] = 0
 


### PR DESCRIPTION
Equilibrage du taux d'esquive à un random entre 1 et 20.

Révise le calcul des dégâts lors de l'action de BLOCAGE. Le nouvel algorithme vérifie si le niveau d'armure est supérieur à celui de l'attaque de l'ennemi. En cas de supériorité, les dégâts sont annulés et l'armure est réduite d'un niveau. Dans le cas contraire, la différence entre l'armure et l'attaque représente les dégâts infligés.